### PR TITLE
[infra] 鎖定 Ollama num_ctx=4096(R1 速度 0.9→22 t/s)

### DIFF
--- a/.agents/gpu-runner.md
+++ b/.agents/gpu-runner.md
@@ -64,7 +64,47 @@ TEMPERATURE = 0.7
 TOP_P = 0.95
 MAX_TOKENS = 800
 NUM_SAMPLES_PER_PROMPT = 3
+
+# Ollama 專用:必須帶,否則速度會崩(見下節 root cause)
+OLLAMA_NUM_CTX = 4096
 ```
+
+### ⚠️ Ollama context 必須鎖 4096(否則速度差 28×)
+
+**Root cause**:Ollama 對 deepseek-r1:70b 預設 `num_ctx=131072`(131K)。
+- KV cache 吃 **40 GB** VRAM
+- RTX Pro 6000 96GB 加上模型權重不夠裝完整 81 layers
+- **6 層被擠到 CPU** → 0.9 t/s(完全跑不動)
+
+**強制設定 `num_ctx=4096`**:
+- KV cache 從 40 GB → ~1 GB
+- 81 層全進 GPU → **30.5 t/s**
+- 我們的 prompt 都 < 200 tokens、`MAX_TOKENS=800`,4096 綽綽有餘
+
+**所有 Ollama API 呼叫都要帶**:
+```python
+requests.post(f"{OLLAMA_HOST}/api/chat", json={
+    "model": model_id,
+    "messages": [...],
+    "stream": False,
+    "options": {
+        "temperature": TEMPERATURE,
+        "top_p": TOP_P,
+        "num_predict": MAX_TOKENS,
+        "num_ctx": OLLAMA_NUM_CTX,   # ← 不可省
+    }
+})
+```
+
+### Reasoning 模型的 thinking 欄位處理
+
+DeepSeek R1 / Qwen3 / GLM 等 reasoning 模型在 `/api/chat` 回傳:
+- `message.content` = 最終答案(已剝乾淨)
+- `message.thinking` = 思考過程(獨立欄位,**不再是 `<think>` 標籤**)
+
+寫進 `data/raw/` 時:
+- 主 `response` 欄位填 `message.content`
+- 把 `message.thinking` 放進 `raw_metadata.thinking`(供 Feature Extractor 之後挖「思考量比」當風格特徵)
 
 ---
 
@@ -119,6 +159,22 @@ for m in deepseek-r1:70b qwen3.6:35b-a3b gemma4:31b; do
     OLLAMA_HOST=127.0.0.1:11502 ollama show $m > /dev/null || echo "MISSING: $m"
 done
 ```
+
+### 1b. Sanity check: 確認 num_ctx 已鎖到 4096 並且 100% GPU offload
+
+第一個採樣前,先發一筆熱身 + 用 `ollama ps` 驗證:
+
+```bash
+# 熱身一筆(會載入模型)
+curl -s http://127.0.0.1:11502/api/chat -d '{"model":"deepseek-r1:70b","messages":[{"role":"user","content":"hi"}],"stream":false,"options":{"num_ctx":4096,"num_predict":50}}' > /dev/null
+
+# 驗證:PROCESSOR 欄必須是 100% GPU
+OLLAMA_HOST=127.0.0.1:11502 ollama ps
+# 預期:NAME              PROCESSOR
+#       deepseek-r1:70b   100% GPU      ← 不能有 CPU!
+```
+
+如果出現任何 `XX% CPU/YY% GPU`,**立刻停止採樣**,檢查 `num_ctx` 是否真的傳進去了。
 
 ### 2. Pilot 跑
 ```bash

--- a/scripts/common/schema.py
+++ b/scripts/common/schema.py
@@ -18,6 +18,12 @@ TOP_P = 0.95
 MAX_TOKENS = 800
 NUM_SAMPLES_PER_PROMPT = 3
 
+# Ollama-specific: cap context window to avoid KV cache forcing CPU offload.
+# Default 131072 makes deepseek-r1:70b spill 6 layers to CPU on RTX Pro 6000
+# (40 GB KV cache); 4096 keeps all layers on GPU and gives ~30 t/s instead of 0.9.
+# Our prompts are all <200 tokens and MAX_TOKENS=800, so 4096 is ample.
+OLLAMA_NUM_CTX = 4096
+
 # Provider categories
 PROVIDERS = Literal["anthropic", "openai", "google", "groq", "ollama"]
 FAMILIES = Literal[


### PR DESCRIPTION
## What
Closes #3

把 Ollama 採樣的 `num_ctx` 鎖在 4096,解決 deepseek-r1:70b KV cache 把 layer 擠到 CPU 的瓶頸。

## Why
PM 已 debug 確認:預設 `num_ctx=131072` 讓 KV cache 吃 40 GB,RTX Pro 6000 96GB 不夠裝完整 81 層,**6 層 offload 到 CPU**,速度 0.9 t/s。

鎖 4096 後:KV cache 1 GB、81 層全 GPU、速度回到 22 t/s(R1)/ 40 t/s(gemma)。

## Verification(我這次提交前實測)

| 模型 | tokens | 速度 | PROCESSOR |
|------|--------|------|-----------|
| deepseek-r1:70b | 389 | **22.0 t/s** | 100% GPU |
| gemma4:31b | 396 | **39.6 t/s** | 100% GPU |

`ollama ps` 顯示 CONTEXT=4096、PROCESSOR=100% GPU,no spill。

## Changes

### `scripts/common/schema.py`
新增採樣常數(不動 SamplingResult / validate 邏輯):
```python
OLLAMA_NUM_CTX = 4096
```
附註解說明 root cause,讓未來 agent 不會疑惑為何 hard-code。

### `.agents/gpu-runner.md`
- 採樣參數區加 `OLLAMA_NUM_CTX = 4096` 常數
- 新增「⚠️ Ollama context 必須鎖 4096」section,解釋 root cause + 給標準 `requests.post(...)` 範例
- 新增「Sanity check」步驟:採樣前用 `ollama ps` 驗證 PROCESSOR=100% GPU(出現 CPU 立刻停)
- 新增「Reasoning 模型 thinking 欄位處理」段:Ollama 已自動把 R1 的 thinking 拆到 `message.thinking`,寫入 `raw_metadata.thinking`(不動主 schema 的 `response` 欄位)

## Schema impact
- [x] **沒動 schema 結構**(SamplingResult dataclass、validate_result、TEMPERATURE/MAX_TOKENS/TOP_P/NUM_SAMPLES_PER_PROMPT 都沒動)
- [x] 新增了一個 Ollama 專用採樣常數 `OLLAMA_NUM_CTX`,屬於採樣參數變更性質(CLAUDE.md 規範:採樣參數變更需 PR review)→ 走本 PR

## Secret check
- [x] 已跑 grep,無命中
- [x] `.env` 不在這個 PR

## Reviewer
@timwei0801

## Next(merge 後)
我會立刻開 Issue #2 派 Prompt Designer 跑第一輪 100 題草稿,啟動 W2 Phase 1。